### PR TITLE
Increase size of PostalCodeRegex field

### DIFF
--- a/Database.GeoNames.org/Tables/gno.CountryInfo.sql
+++ b/Database.GeoNames.org/Tables/gno.CountryInfo.sql
@@ -14,7 +14,7 @@
   [CurrencyName] VARCHAR(20),
   [Phone] VARCHAR(20),
   [PostalCodeFormat] VARCHAR(100),
-  [PostalCodeRegex] VARCHAR(150),
+  [PostalCodeRegex] VARCHAR(200),
   [Languages] VARCHAR(100),
   [GeonameId] INT NOT NULL,
   [Neighbours] VARCHAR(50),


### PR DESCRIPTION
At least one entry in the flat file exceeds the existing length (United Kingdom), thus leaving it out of the import.